### PR TITLE
Add link to GitHub Markdown documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Här finns information om hur man arbetar med hemsidan.
 
 ### Markdown
 
-<!-- TODO -->
+Läs mer om markdown [här](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
 
 ### HTML
 


### PR DESCRIPTION
Updated the Markdown section with a link to GitHub documentation.